### PR TITLE
fix: Access denied from forwarder when using s3_log_bucket_arns

### DIFF
--- a/modules/log_forwarder/main.tf
+++ b/modules/log_forwarder/main.tf
@@ -96,7 +96,7 @@ resource "aws_iam_policy" "this" {
     {
       vpc_check             = var.subnet_ids != null
       s3_check              = length(var.s3_log_bucket_arns) > 0
-      s3_log_bucket_arns    = jsonencode(var.s3_log_bucket_arns)
+      s3_log_bucket_arns    = jsonencode(concat(var.s3_log_bucket_arns, formatlist("%s/*", var.s3_log_bucket_arns)))
       datadog_s3_bucket     = "arn:aws:s3:::${local.bucket_name}"
       dd_api_key_secret_arn = var.dd_api_key_secret_arn
     }


### PR DESCRIPTION
## Description
The lambda forwarder needs permissions to GetObject inside the bucket, much like the Datadog S3 bucket

## Motivation and Context
While leveraging the `s3_log_bucket_arns` variable we get an `Access Denied` error from the lambda log forwarder due to the lack of permissions.

```
An error occurred (AccessDenied) when calling the GetObject operation.
```

## Breaking Changes
None.

## How Has This Been Tested?

```
> jsonencode(concat(formatlist("%s/*", ["arn:aws:s3:::example-bucket", "arn:aws:s3:::example-log-bucket"]), ["arn:aws:s3:::example-bucket", "arn:aws:s3:::example-log-bucket"]))
"[\"arn:aws:s3:::example-bucket/*\",\"arn:aws:s3:::example-log-bucket/*\",\"arn:aws:s3:::example-bucket\",\"arn:aws:s3:::example-log-bucket\"]"
```

**I'll try and get time to complete the below soon**
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request

