### PR TITLE
fix: Change default runtime to python3.11 to support latest forwarder version

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | <a name="input_log_forwarder_role_path"></a> [log\_forwarder\_role\_path](#input\_log\_forwarder\_role\_path) | Log forwarder role path | `string` | `null` | no |
 | <a name="input_log_forwarder_role_permissions_boundary"></a> [log\_forwarder\_role\_permissions\_boundary](#input\_log\_forwarder\_role\_permissions\_boundary) | The ARN of the policy that is used to set the permissions boundary for the log forwarder role | `string` | `null` | no |
 | <a name="input_log_forwarder_role_tags"></a> [log\_forwarder\_role\_tags](#input\_log\_forwarder\_role\_tags) | A map of tags to apply to the log forwarder role | `map(string)` | `{}` | no |
-| <a name="input_log_forwarder_runtime"></a> [log\_forwarder\_runtime](#input\_log\_forwarder\_runtime) | Lambda function runtime | `string` | `"python3.8"` | no |
+| <a name="input_log_forwarder_runtime"></a> [log\_forwarder\_runtime](#input\_log\_forwarder\_runtime) | Lambda function runtime | `string` | `"python3.11"` | no |
 | <a name="input_log_forwarder_s3_log_bucket_arns"></a> [log\_forwarder\_s3\_log\_bucket\_arns](#input\_log\_forwarder\_s3\_log\_bucket\_arns) | S3 log buckets for forwarder to read and forward logs to Datadog | `list(string)` | `[]` | no |
 | <a name="input_log_forwarder_s3_zip_kms_key_id"></a> [log\_forwarder\_s3\_zip\_kms\_key\_id](#input\_log\_forwarder\_s3\_zip\_kms\_key\_id) | The AWS KMS Key ARN to use for object encryption | `string` | `null` | no |
 | <a name="input_log_forwarder_s3_zip_metadata"></a> [log\_forwarder\_s3\_zip\_metadata](#input\_log\_forwarder\_s3\_zip\_metadata) | A map of keys/values to provision metadata (will be automatically prefixed by `x-amz-meta-` | `map(string)` | `{}` | no |

--- a/modules/log_forwarder/README.md
+++ b/modules/log_forwarder/README.md
@@ -111,7 +111,7 @@ module "datadog_log_forwarder" {
 | <a name="input_role_path"></a> [role\_path](#input\_role\_path) | Forwarder role path | `string` | `null` | no |
 | <a name="input_role_permissions_boundary"></a> [role\_permissions\_boundary](#input\_role\_permissions\_boundary) | The ARN of the policy that is used to set the permissions boundary for the forwarder role | `string` | `null` | no |
 | <a name="input_role_tags"></a> [role\_tags](#input\_role\_tags) | A map of tags to apply to the forwarder role | `map(string)` | `{}` | no |
-| <a name="input_runtime"></a> [runtime](#input\_runtime) | Lambda function runtime | `string` | `"python3.8"` | no |
+| <a name="input_runtime"></a> [runtime](#input\_runtime) | Lambda function runtime | `string` | `"python3.11"` | no |
 | <a name="input_s3_log_bucket_arns"></a> [s3\_log\_bucket\_arns](#input\_s3\_log\_bucket\_arns) | S3 log buckets for forwarder to read and forward logs to Datadog | `list(string)` | `[]` | no |
 | <a name="input_s3_zip_kms_key_id"></a> [s3\_zip\_kms\_key\_id](#input\_s3\_zip\_kms\_key\_id) | The AWS KMS Key ARN to use for object encryption | `string` | `null` | no |
 | <a name="input_s3_zip_metadata"></a> [s3\_zip\_metadata](#input\_s3\_zip\_metadata) | A map of keys/values to provision metadata (will be automatically prefixed by `x-amz-meta-` | `map(string)` | `{}` | no |

--- a/modules/log_forwarder/variables.tf
+++ b/modules/log_forwarder/variables.tf
@@ -200,7 +200,7 @@ variable "name" {
 variable "runtime" {
   description = "Lambda function runtime"
   type        = string
-  default     = "python3.8"
+  default     = "python3.11"
 }
 
 variable "layers" {

--- a/modules/rds_enhanced_monitoring_forwarder/README.md
+++ b/modules/rds_enhanced_monitoring_forwarder/README.md
@@ -87,7 +87,7 @@ No modules.
 | <a name="input_role_path"></a> [role\_path](#input\_role\_path) | Forwarder role path | `string` | `null` | no |
 | <a name="input_role_permissions_boundary"></a> [role\_permissions\_boundary](#input\_role\_permissions\_boundary) | The ARN of the policy that is used to set the permissions boundary for the forwarder role. | `string` | `null` | no |
 | <a name="input_role_tags"></a> [role\_tags](#input\_role\_tags) | A map of tags to apply to the forwarder role | `map(string)` | `{}` | no |
-| <a name="input_runtime"></a> [runtime](#input\_runtime) | Lambda function runtime | `string` | `"python3.8"` | no |
+| <a name="input_runtime"></a> [runtime](#input\_runtime) | Lambda function runtime | `string` | `"python3.11"` | no |
 | <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | List of security group ids when Lambda Function should run in the VPC. | `list(string)` | `null` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | List of subnet ids when Lambda Function should run in the VPC. Usually private or intra subnets. | `list(string)` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to use on all resources | `map(string)` | `{}` | no |

--- a/modules/rds_enhanced_monitoring_forwarder/variables.tf
+++ b/modules/rds_enhanced_monitoring_forwarder/variables.tf
@@ -124,7 +124,7 @@ variable "name" {
 variable "runtime" {
   description = "Lambda function runtime"
   type        = string
-  default     = "python3.8"
+  default     = "python3.11"
 }
 
 variable "layers" {

--- a/modules/vpc_flow_log_forwarder/README.md
+++ b/modules/vpc_flow_log_forwarder/README.md
@@ -93,7 +93,7 @@ No modules.
 | <a name="input_role_path"></a> [role\_path](#input\_role\_path) | Forwarder role path | `string` | `null` | no |
 | <a name="input_role_permissions_boundary"></a> [role\_permissions\_boundary](#input\_role\_permissions\_boundary) | The ARN of the policy that is used to set the permissions boundary for the forwarder role | `string` | `null` | no |
 | <a name="input_role_tags"></a> [role\_tags](#input\_role\_tags) | A map of tags to apply to the forwarder role | `map(string)` | `{}` | no |
-| <a name="input_runtime"></a> [runtime](#input\_runtime) | Lambda function runtime | `string` | `"python3.8"` | no |
+| <a name="input_runtime"></a> [runtime](#input\_runtime) | Lambda function runtime | `string` | `"python3.11"` | no |
 | <a name="input_s3_log_bucket_arns"></a> [s3\_log\_bucket\_arns](#input\_s3\_log\_bucket\_arns) | S3 log buckets for forwarder to read and forward VPC flow logs to Datadog | `list(string)` | `[]` | no |
 | <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | List of security group ids when Lambda Function should run in the VPC | `list(string)` | `null` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | List of subnet ids when Lambda Function should run in the VPC. Usually private or intra subnets | `list(string)` | `null` | no |

--- a/modules/vpc_flow_log_forwarder/variables.tf
+++ b/modules/vpc_flow_log_forwarder/variables.tf
@@ -141,7 +141,7 @@ variable "name" {
 variable "runtime" {
   description = "Lambda function runtime"
   type        = string
-  default     = "python3.8"
+  default     = "python3.11"
 }
 
 variable "layers" {

--- a/variables.tf
+++ b/variables.tf
@@ -211,7 +211,7 @@ variable "log_forwarder_name" {
 variable "log_forwarder_runtime" {
   description = "Lambda function runtime"
   type        = string
-  default     = "python3.8"
+  default     = "python3.11"
 }
 
 variable "log_forwarder_layers" {


### PR DESCRIPTION
## Description
Follow up from #36.
Believe the default runtime needs to be `python3.11` to support version `3.103.0` of the forwarder.
Otherwise runs into https://github.com/urllib3/urllib3/issues/2168 

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
