### PR TITLE
fix: Update CI workflow versions to latest

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       # Please look up the latest version from
       # https://github.com/amannn/action-semantic-pull-request/releases
-      - uses: amannn/action-semantic-pull-request@v5.4.0
+      - uses: amannn/action-semantic-pull-request@v5.5.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,8 +7,8 @@ on:
       - master
 
 env:
-  TERRAFORM_DOCS_VERSION: v0.16.0
-  TFLINT_VERSION: v0.50.3
+  TERRAFORM_DOCS_VERSION: v0.19.0
+  TFLINT_VERSION: v0.53.0
 
 jobs:
   collectInputs:
@@ -45,14 +45,14 @@ jobs:
 
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v1.3.0
+        uses: clowdhaus/terraform-min-max@v1.3.1
         with:
           directory: ${{ matrix.directory }}
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.minVersion }}
         # Run only validate pre-commit check on min version supported
         if: ${{ matrix.directory !=  '.' }}
-        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.9.0
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.11.1
         with:
           terraform-version: ${{ steps.minMax.outputs.minVersion }}
           tflint-version: ${{ env.TFLINT_VERSION }}
@@ -61,7 +61,7 @@ jobs:
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.minVersion }}
         # Run only validate pre-commit check on min version supported
         if: ${{ matrix.directory ==  '.' }}
-        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.9.0
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.11.1
         with:
           terraform-version: ${{ steps.minMax.outputs.minVersion }}
           tflint-version: ${{ env.TFLINT_VERSION }}
@@ -88,10 +88,10 @@ jobs:
 
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v1.3.0
+        uses: clowdhaus/terraform-min-max@v1.3.1
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.maxVersion }}
-        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.9.0
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.11.1
         with:
           terraform-version: ${{ steps.minMax.outputs.maxVersion }}
           tflint-version: ${{ env.TFLINT_VERSION }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.88.0
+    rev: v1.96.1
     hooks:
       - id: terraform_fmt
       - id: terraform_docs
@@ -21,10 +21,9 @@ repos:
           - '--args=--only=terraform_required_providers'
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
-          - '--args=--only=terraform_unused_required_providers'
       - id: terraform_validate
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 - [Complete](https://github.com/terraform-aws-modules/terraform-aws-datadog-forwarders/tree/master/examples/complete)
 - [Simple](https://github.com/terraform-aws-modules/terraform-aws-datadog-forwarders/tree/master/examples/simple)
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -106,7 +106,7 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | <a name="input_api_vpce_subnet_ids"></a> [api\_vpce\_subnet\_ids](#input\_api\_vpce\_subnet\_ids) | IDs of subnets to associate with API endpoint | `list(string)` | `[]` | no |
 | <a name="input_api_vpce_tags"></a> [api\_vpce\_tags](#input\_api\_vpce\_tags) | A map of tags to apply to the API endpoint | `map(string)` | `{}` | no |
 | <a name="input_bucket_attach_deny_insecure_transport_policy"></a> [bucket\_attach\_deny\_insecure\_transport\_policy](#input\_bucket\_attach\_deny\_insecure\_transport\_policy) | Controls if S3 bucket should have deny non-SSL transport policy attacheds | `bool` | `true` | no |
-| <a name="input_bucket_encryption_settings"></a> [bucket\_encryption\_settings](#input\_bucket\_encryption\_settings) | S3 bucket server side encryption settings | `map(string)` | <pre>{<br>  "sse_algorithm": "AES256"<br>}</pre> | no |
+| <a name="input_bucket_encryption_settings"></a> [bucket\_encryption\_settings](#input\_bucket\_encryption\_settings) | S3 bucket server side encryption settings | `map(string)` | <pre>{<br/>  "sse_algorithm": "AES256"<br/>}</pre> | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Lambda artifact S3 bucket name | `string` | `""` | no |
 | <a name="input_create_agent_vpce"></a> [create\_agent\_vpce](#input\_create\_agent\_vpce) | Controls whether an agent endpoint should be created | `bool` | `false` | no |
 | <a name="input_create_api_vpce"></a> [create\_api\_vpce](#input\_create\_api\_vpce) | Controls whether a API endpoint should be created | `bool` | `false` | no |
@@ -129,7 +129,7 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | <a name="input_dd_app_key"></a> [dd\_app\_key](#input\_dd\_app\_key) | The Datadog application key associated with the user account that created it, which can be found from the APIs page | `string` | `""` | no |
 | <a name="input_dd_site"></a> [dd\_site](#input\_dd\_site) | Define your Datadog Site to send data to. For the Datadog EU site, set to datadoghq.eu | `string` | `"datadoghq.com"` | no |
 | <a name="input_kms_alias"></a> [kms\_alias](#input\_kms\_alias) | Alias of KMS key used to encrypt the Datadog API keys - must start with `alias/` | `string` | n/a | yes |
-| <a name="input_log_forwarder_architectures"></a> [log\_forwarder\_architectures](#input\_log\_forwarder\_architectures) | Instruction set architecture for your Lambda function. Valid values are `["x86_64"]` and `["arm64"]`. Default is `["x86_64"]` | `list(string)` | <pre>[<br>  "x86_64"<br>]</pre> | no |
+| <a name="input_log_forwarder_architectures"></a> [log\_forwarder\_architectures](#input\_log\_forwarder\_architectures) | Instruction set architecture for your Lambda function. Valid values are `["x86_64"]` and `["arm64"]`. Default is `["x86_64"]` | `list(string)` | <pre>[<br/>  "x86_64"<br/>]</pre> | no |
 | <a name="input_log_forwarder_bucket_prefix"></a> [log\_forwarder\_bucket\_prefix](#input\_log\_forwarder\_bucket\_prefix) | S3 object key prefix to prepend to zip archive name | `string` | `""` | no |
 | <a name="input_log_forwarder_bucket_tags"></a> [log\_forwarder\_bucket\_tags](#input\_log\_forwarder\_bucket\_tags) | A map of tags to apply to the log forwarder bucket | `map(any)` | `{}` | no |
 | <a name="input_log_forwarder_environment_variables"></a> [log\_forwarder\_environment\_variables](#input\_log\_forwarder\_environment\_variables) | A map of environment variables for the log forwarder lambda function | `map(string)` | `{}` | no |
@@ -178,7 +178,7 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | <a name="input_processes_vpce_security_group_ids"></a> [processes\_vpce\_security\_group\_ids](#input\_processes\_vpce\_security\_group\_ids) | IDs of security groups to attach to processes endpoint | `list(string)` | `[]` | no |
 | <a name="input_processes_vpce_subnet_ids"></a> [processes\_vpce\_subnet\_ids](#input\_processes\_vpce\_subnet\_ids) | IDs of subnets to associate with processes endpoint | `list(string)` | `[]` | no |
 | <a name="input_processes_vpce_tags"></a> [processes\_vpce\_tags](#input\_processes\_vpce\_tags) | A map of tags to apply to the processes endpoint | `map(string)` | `{}` | no |
-| <a name="input_rds_em_forwarder_architectures"></a> [rds\_em\_forwarder\_architectures](#input\_rds\_em\_forwarder\_architectures) | Instruction set architecture for your Lambda function. Valid values are `["x86_64"]` and `["arm64"]`. Default is `["x86_64"]` | `list(string)` | <pre>[<br>  "x86_64"<br>]</pre> | no |
+| <a name="input_rds_em_forwarder_architectures"></a> [rds\_em\_forwarder\_architectures](#input\_rds\_em\_forwarder\_architectures) | Instruction set architecture for your Lambda function. Valid values are `["x86_64"]` and `["arm64"]`. Default is `["x86_64"]` | `list(string)` | <pre>[<br/>  "x86_64"<br/>]</pre> | no |
 | <a name="input_rds_em_forwarder_environment_variables"></a> [rds\_em\_forwarder\_environment\_variables](#input\_rds\_em\_forwarder\_environment\_variables) | A map of environment variables for the RDS enhanced monitoring forwarder lambda function | `map(string)` | `{}` | no |
 | <a name="input_rds_em_forwarder_kms_key_arn"></a> [rds\_em\_forwarder\_kms\_key\_arn](#input\_rds\_em\_forwarder\_kms\_key\_arn) | KMS key that is used to encrypt environment variables. If this configuration is not provided when environment variables are in use, AWS Lambda uses a default service key | `string` | `null` | no |
 | <a name="input_rds_em_forwarder_lambda_tags"></a> [rds\_em\_forwarder\_lambda\_tags](#input\_rds\_em\_forwarder\_lambda\_tags) | A map of tags to apply to the RDS enhanced monitoring forwarder lambda function | `map(string)` | `{}` | no |
@@ -211,7 +211,7 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | <a name="input_traces_vpce_security_group_ids"></a> [traces\_vpce\_security\_group\_ids](#input\_traces\_vpce\_security\_group\_ids) | IDs of security groups to attach to traces endpoint | `list(string)` | `[]` | no |
 | <a name="input_traces_vpce_subnet_ids"></a> [traces\_vpce\_subnet\_ids](#input\_traces\_vpce\_subnet\_ids) | IDs of subnets to associate with traces endpoint | `list(string)` | `[]` | no |
 | <a name="input_traces_vpce_tags"></a> [traces\_vpce\_tags](#input\_traces\_vpce\_tags) | A map of tags to apply to the traces endpoint | `map(string)` | `{}` | no |
-| <a name="input_vpc_fl_forwarder_architectures"></a> [vpc\_fl\_forwarder\_architectures](#input\_vpc\_fl\_forwarder\_architectures) | Instruction set architecture for your Lambda function. Valid values are `["x86_64"]` and `["arm64"]`. Default is `["x86_64"]` | `list(string)` | <pre>[<br>  "x86_64"<br>]</pre> | no |
+| <a name="input_vpc_fl_forwarder_architectures"></a> [vpc\_fl\_forwarder\_architectures](#input\_vpc\_fl\_forwarder\_architectures) | Instruction set architecture for your Lambda function. Valid values are `["x86_64"]` and `["arm64"]`. Default is `["x86_64"]` | `list(string)` | <pre>[<br/>  "x86_64"<br/>]</pre> | no |
 | <a name="input_vpc_fl_forwarder_environment_variables"></a> [vpc\_fl\_forwarder\_environment\_variables](#input\_vpc\_fl\_forwarder\_environment\_variables) | A map of environment variables for the VPC flow log forwarder lambda function | `map(string)` | `{}` | no |
 | <a name="input_vpc_fl_forwarder_kms_key_arn"></a> [vpc\_fl\_forwarder\_kms\_key\_arn](#input\_vpc\_fl\_forwarder\_kms\_key\_arn) | KMS key that is used to encrypt environment variables. If this configuration is not provided when environment variables are in use, AWS Lambda uses a default service key | `string` | `null` | no |
 | <a name="input_vpc_fl_forwarder_lambda_tags"></a> [vpc\_fl\_forwarder\_lambda\_tags](#input\_vpc\_fl\_forwarder\_lambda\_tags) | A map of tags to apply to the VPC flow log forwarder lambda function | `map(string)` | `{}` | no |
@@ -329,7 +329,7 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | <a name="output_vpc_fl_forwarder_role_policy_id"></a> [vpc\_fl\_forwarder\_role\_policy\_id](#output\_vpc\_fl\_forwarder\_role\_policy\_id) | The ID of the VPC flow log forwarder lambda role policy |
 | <a name="output_vpc_fl_forwarder_role_policy_name"></a> [vpc\_fl\_forwarder\_role\_policy\_name](#output\_vpc\_fl\_forwarder\_role\_policy\_name) | The name of the VPC flow log forwarder lambda role policy |
 | <a name="output_vpc_fl_forwarder_role_unique_id"></a> [vpc\_fl\_forwarder\_role\_unique\_id](#output\_vpc\_fl\_forwarder\_role\_unique\_id) | The stable and unique string identifying the VPC flow log forwarder lambda role. |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->
 
 ## License
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -18,7 +18,7 @@ $ terraform apply
 
 Note that this example may create resources which will incur monetary charges on your AWS bill. Run `terraform destroy` when you no longer need these resources.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -132,6 +132,6 @@ No inputs.
 | <a name="output_vpc_fl_forwarder_role_name"></a> [vpc\_fl\_forwarder\_role\_name](#output\_vpc\_fl\_forwarder\_role\_name) | The VPC flow log forwarder lambda role name |
 | <a name="output_vpc_fl_forwarder_role_policy_arn"></a> [vpc\_fl\_forwarder\_role\_policy\_arn](#output\_vpc\_fl\_forwarder\_role\_policy\_arn) | The ARN of the VPC flow log forwarder lambda role policy |
 | <a name="output_vpc_fl_forwarder_role_policy_name"></a> [vpc\_fl\_forwarder\_role\_policy\_name](#output\_vpc\_fl\_forwarder\_role\_policy\_name) | The name of the VPC flow log forwarder lambda role policy |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->
 
 Apache-2.0 Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-aws-datadog-forwarders/blob/master/LICENSE).

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -14,7 +14,7 @@ $ terraform apply
 
 Note that this example may create resources which will incur monetary charges on your AWS bill. Run `terraform destroy` when you no longer need these resources.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -84,6 +84,6 @@ No inputs.
 | <a name="output_vpc_fl_forwarder_role_name"></a> [vpc\_fl\_forwarder\_role\_name](#output\_vpc\_fl\_forwarder\_role\_name) | The VPC flow log forwarder lambda role name |
 | <a name="output_vpc_fl_forwarder_role_policy_arn"></a> [vpc\_fl\_forwarder\_role\_policy\_arn](#output\_vpc\_fl\_forwarder\_role\_policy\_arn) | The ARN of the VPC flow log forwarder lambda role policy |
 | <a name="output_vpc_fl_forwarder_role_policy_name"></a> [vpc\_fl\_forwarder\_role\_policy\_name](#output\_vpc\_fl\_forwarder\_role\_policy\_name) | The name of the VPC flow log forwarder lambda role policy |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->
 
 Apache-2.0 Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-aws-datadog-forwarders/blob/master/LICENSE).

--- a/modules/log_forwarder/README.md
+++ b/modules/log_forwarder/README.md
@@ -36,7 +36,7 @@ module "datadog_log_forwarder" {
 }
 ```
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -79,9 +79,9 @@ module "datadog_log_forwarder" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_architectures"></a> [architectures](#input\_architectures) | Instruction set architecture for your Lambda function. Valid values are `["x86_64"]` and `["arm64"]`. Default is `["x86_64"]` | `list(string)` | <pre>[<br>  "x86_64"<br>]</pre> | no |
+| <a name="input_architectures"></a> [architectures](#input\_architectures) | Instruction set architecture for your Lambda function. Valid values are `["x86_64"]` and `["arm64"]`. Default is `["x86_64"]` | `list(string)` | <pre>[<br/>  "x86_64"<br/>]</pre> | no |
 | <a name="input_bucket_attach_deny_insecure_transport_policy"></a> [bucket\_attach\_deny\_insecure\_transport\_policy](#input\_bucket\_attach\_deny\_insecure\_transport\_policy) | Controls if S3 bucket should have deny non-SSL transport policy attacheds | `bool` | `false` | no |
-| <a name="input_bucket_encryption_settings"></a> [bucket\_encryption\_settings](#input\_bucket\_encryption\_settings) | S3 bucket server side encryption settings | `map(string)` | <pre>{<br>  "sse_algorithm": "AES256"<br>}</pre> | no |
+| <a name="input_bucket_encryption_settings"></a> [bucket\_encryption\_settings](#input\_bucket\_encryption\_settings) | S3 bucket server side encryption settings | `map(string)` | <pre>{<br/>  "sse_algorithm": "AES256"<br/>}</pre> | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Forwarder S3 bucket name | `string` | `""` | no |
 | <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | S3 object key prefix to prepend to zip archive name | `string` | `""` | no |
 | <a name="input_bucket_tags"></a> [bucket\_tags](#input\_bucket\_tags) | A map of tags to apply to the bucket | `map(string)` | `{}` | no |
@@ -151,7 +151,7 @@ module "datadog_log_forwarder" {
 | <a name="output_s3_object_etag"></a> [s3\_object\_etag](#output\_s3\_object\_etag) | The ETag generated for the forwarder lambda zip object (an MD5 sum of the object content) |
 | <a name="output_s3_object_id"></a> [s3\_object\_id](#output\_s3\_object\_id) | The `key` of the forwarder lambda zip archive |
 | <a name="output_s3_object_version"></a> [s3\_object\_version](#output\_s3\_object\_version) | A unique version ID value for the forwarder lambda zip object, if bucket versioning is enabled |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->
 
 ## License
 

--- a/modules/rds_enhanced_monitoring_forwarder/README.md
+++ b/modules/rds_enhanced_monitoring_forwarder/README.md
@@ -24,7 +24,7 @@ module "datadog_rds_enhanced_monitoring_forwarder" {
 }
 ```
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -60,7 +60,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_architectures"></a> [architectures](#input\_architectures) | Instruction set architecture for your Lambda function. Valid values are `["x86_64"]` and `["arm64"]`. Default is `["x86_64"]` | `list(string)` | <pre>[<br>  "x86_64"<br>]</pre> | no |
+| <a name="input_architectures"></a> [architectures](#input\_architectures) | Instruction set architecture for your Lambda function. Valid values are `["x86_64"]` and `["arm64"]`. Default is `["x86_64"]` | `list(string)` | <pre>[<br/>  "x86_64"<br/>]</pre> | no |
 | <a name="input_create"></a> [create](#input\_create) | Controls whether the forwarder resources should be created | `bool` | `true` | no |
 | <a name="input_create_role"></a> [create\_role](#input\_create\_role) | Controls whether an IAM role is created for the forwarder | `bool` | `true` | no |
 | <a name="input_create_role_policy"></a> [create\_role\_policy](#input\_create\_role\_policy) | Controls whether an IAM role policy is created for the forwarder | `bool` | `true` | no |
@@ -112,7 +112,7 @@ No modules.
 | <a name="output_role_policy_id"></a> [role\_policy\_id](#output\_role\_policy\_id) | The ID of the forwarder lambda role policy |
 | <a name="output_role_policy_name"></a> [role\_policy\_name](#output\_role\_policy\_name) | The name of the forwarder lambda role policy |
 | <a name="output_role_unique_id"></a> [role\_unique\_id](#output\_role\_unique\_id) | The stable and unique string identifying the forwarder lambda role |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->
 
 ## License
 

--- a/modules/vpc_flow_log_forwarder/README.md
+++ b/modules/vpc_flow_log_forwarder/README.md
@@ -24,7 +24,7 @@ module "datadog_vpc_flow_log_forwarder" {
 }
 ```
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -64,7 +64,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_architectures"></a> [architectures](#input\_architectures) | Instruction set architecture for your Lambda function. Valid values are `["x86_64"]` and `["arm64"]`. Default is `["x86_64"]` | `list(string)` | <pre>[<br>  "x86_64"<br>]</pre> | no |
+| <a name="input_architectures"></a> [architectures](#input\_architectures) | Instruction set architecture for your Lambda function. Valid values are `["x86_64"]` and `["arm64"]`. Default is `["x86_64"]` | `list(string)` | <pre>[<br/>  "x86_64"<br/>]</pre> | no |
 | <a name="input_create"></a> [create](#input\_create) | Controls whether the forwarder resources should be created | `bool` | `true` | no |
 | <a name="input_create_role"></a> [create\_role](#input\_create\_role) | Controls whether an IAM role is created for the forwarder | `bool` | `true` | no |
 | <a name="input_create_role_policy"></a> [create\_role\_policy](#input\_create\_role\_policy) | Controls whether an IAM role policy is created for the forwarder | `bool` | `true` | no |
@@ -119,6 +119,6 @@ No modules.
 | <a name="output_role_policy_id"></a> [role\_policy\_id](#output\_role\_policy\_id) | The ID of the forwarder lambda role policy |
 | <a name="output_role_policy_name"></a> [role\_policy\_name](#output\_role\_policy\_name) | The name of the forwarder lambda role policy |
 | <a name="output_role_unique_id"></a> [role\_unique\_id](#output\_role\_unique\_id) | The stable and unique string identifying the forwarder lambda role |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->
 
 Apache-2.0 Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-aws-datadog-forwarders/blob/master/LICENSE).


### PR DESCRIPTION
## Description

- Update CI workflow versions to latest

## Motivation and Context

- Updates our workflows to use the latest versions
- Removes warnings for Python 3.12 in runners

## Breaking Changes

- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
