### PR TITLE
fix: Replace deprecated data.aws_region.current.name with data.aws_region.current.region

### DIFF
--- a/modules/log_forwarder/main.tf
+++ b/modules/log_forwarder/main.tf
@@ -1,5 +1,5 @@
 locals {
-  bucket_name = var.bucket_name != "" ? var.bucket_name : "datadog-forwarder-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.name}"
+  bucket_name = var.bucket_name != "" ? var.bucket_name : "datadog-forwarder-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.region}"
 
   dd_api_key            = var.dd_api_key != "" ? { DD_API_KEY = var.dd_api_key } : {}
   dd_api_key_secret_arn = var.dd_api_key_secret_arn != "" ? { DD_API_KEY_SECRET_ARN = var.dd_api_key_secret_arn } : {}
@@ -205,7 +205,7 @@ resource "aws_lambda_permission" "cloudwatch" {
   statement_id   = "datadog-forwarder-CloudWatchLogsPermission"
   action         = "lambda:InvokeFunction"
   function_name  = aws_lambda_function.this[0].function_name
-  principal      = "logs.${data.aws_region.current.name}.amazonaws.com"
+  principal      = "logs.${data.aws_region.current.region}.amazonaws.com"
   source_account = data.aws_caller_identity.current.account_id
 }
 

--- a/modules/rds_enhanced_monitoring_forwarder/main.tf
+++ b/modules/rds_enhanced_monitoring_forwarder/main.tf
@@ -124,7 +124,7 @@ resource "aws_lambda_permission" "cloudwatch" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.this[0].function_name
   principal     = "logs.amazonaws.com"
-  source_arn    = "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:RDSOSMetrics:*"
+  source_arn    = "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:RDSOSMetrics:*"
 }
 
 resource "aws_cloudwatch_log_group" "this" {

--- a/modules/vpc_flow_log_forwarder/main.tf
+++ b/modules/vpc_flow_log_forwarder/main.tf
@@ -131,7 +131,7 @@ resource "aws_lambda_permission" "cloudwatch" {
   statement_id   = "datadog-forwarder-CloudWatchLogsPermission"
   action         = "lambda:InvokeFunction"
   function_name  = aws_lambda_function.this[0].function_name
-  principal      = "logs.${data.aws_region.current.name}.amazonaws.com"
+  principal      = "logs.${data.aws_region.current.region}.amazonaws.com"
   source_account = data.aws_caller_identity.current.account_id
 }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Replace deprecated region name with region https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Deprecation warning fix
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
