### PR TITLE
chore: Restrict KMS decrypt to allowed services and bucket encryption context

### DIFF
--- a/modules/log_forwarder/policy.tmpl
+++ b/modules/log_forwarder/policy.tmpl
@@ -16,9 +16,23 @@
       "Sid": "AnyResourceAccess"
     },
     {
-      "Action": "kms:Decrypt",
+      "Action": [
+        "kms:Decrypt"
+      ],
       "Effect": "Allow",
       "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "lambda.*.amazonaws.com",
+            "secretsmanager.*.amazonaws.com",
+            "s3.*.amazonaws.com"
+          ]%{ if datadog_s3_bucket != "" },
+          "kms:EncryptionContext:aws:s3:arn": [
+            "${datadog_s3_bucket}/*"
+          ]%{ endif }
+        }
+      },
       "Sid": "KmsDecrypt"
     },
     {

--- a/modules/rds_enhanced_monitoring_forwarder/policy.tmpl
+++ b/modules/rds_enhanced_monitoring_forwarder/policy.tmpl
@@ -15,9 +15,23 @@
       "Sid": "WriteLogs"
     },
     {
-      "Action": "kms:Decrypt",
+      "Action": [
+        "kms:Decrypt"
+      ],
       "Effect": "Allow",
       "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "lambda.*.amazonaws.com",
+            "secretsmanager.*.amazonaws.com"%{ if datadog_s3_bucket != "" },
+            "s3.*.amazonaws.com"%{ endif }
+          ]%{ if datadog_s3_bucket != "" },
+          "kms:EncryptionContext:aws:s3:arn": [
+            "${datadog_s3_bucket}/*"
+          ]%{ endif }
+        }
+      },
       "Sid": "KmsDecrypt"
     }%{ if dd_api_key_secret_arn != "" },
     {

--- a/modules/vpc_flow_log_forwarder/policy.tmpl
+++ b/modules/vpc_flow_log_forwarder/policy.tmpl
@@ -21,9 +21,23 @@
       "Sid": "ReadS3Logs"
     }%{ endif },
     {
-      "Action": "kms:Decrypt",
+      "Action": [
+        "kms:Decrypt"
+      ],
       "Effect": "Allow",
       "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": [
+            "lambda.*.amazonaws.com",
+            "secretsmanager.*.amazonaws.com"%{ if s3_check },
+            "s3.*.amazonaws.com"%{ endif }
+          ]%{ if datadog_s3_bucket != "" },
+          "kms:EncryptionContext:aws:s3:arn": [
+            "${datadog_s3_bucket}/*"
+          ]%{ endif }
+        }
+      },
       "Sid": "KmsDecrypt"
     }
   ]


### PR DESCRIPTION
**Original problem:** 

The Lambda IAM policy granted kms:Decrypt on Resource "*" with no conditions, allowing the function (or anything using its role if compromised) to decrypt data protected by any present or future KMS key in the account, far beyond what it needs (e.g. only its secret or specific bucket objects). This violated least privilege and expanded blast radius in case of credential abuse.

**Changes (What it does):**

- kms:ViaService limits kms:Decrypt usage to requests originating through those AWS services (no direct raw KMS API misuse).

- lambda.*.amazonaws.com → decrypting Lambda environment variables or layers.

- secretsmanager.*.amazonaws.com → retrieving encrypted secrets.

- s3.*.amazonaws.com → reading KMS‑encrypted S3 objects.

Conditional part:
The Go template `%{ if datadog_s3_bucket != "" } ` inserts the` kms:EncryptionContext` condition only if a bucket ARN variable is provided.
`kms:EncryptionContext:aws:s3:arn` further restricts decryption to ciphertext whose encryption context indicates it came from that specific S3 bucket path `(${datadog_s3_bucket}/*)`.
If no bucket provided, that extra restriction is omitted (maintains backward compatibility).
